### PR TITLE
Preserve Template and File Path

### DIFF
--- a/lib/derivative_rodeo/storage_targets/base_target.rb
+++ b/lib/derivative_rodeo/storage_targets/base_target.rb
@@ -157,7 +157,8 @@ module DerivativeRodeo
         raise ArgumentError, 'Expected a block' unless block_given?
 
         tmp_file_dir do |tmpdir|
-          self.tmp_file_path = File.join(tmpdir, file_name)
+          self.tmp_file_path = File.join(tmpdir, file_dir, file_name)
+          FileUtils.mkdir_p(File.dirname(tmp_file_path))
           preamble_lambda.call(file_path, tmp_file_path, exist?)
           yield tmp_file_path
           write if auto_write_file
@@ -215,6 +216,14 @@ module DerivativeRodeo
 
       def file_name
         @file_name ||= File.basename(file_path)
+      end
+
+      def file_extension
+        @file_extension ||= File.extname(file_path)
+      end
+
+      def file_basename
+        @file_basename ||= File.basename(file_path, file_extension)
       end
 
       def tmp_file_dir(&block)

--- a/spec/derivative_rodeo/storage_targets/sqs_target_spec.rb
+++ b/spec/derivative_rodeo/storage_targets/sqs_target_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe DerivativeRodeo::StorageTargets::SqsTarget do
   let(:file_path) { File.expand_path(File.join(FIXTURE_PATH, 'files', 'ocr_color.tiff')) }
   let(:short_path) { file_path.split('/')[-2..-1].join('/') }
-  let(:args) { "sqs://eu-west-1.amazonaws.com/55555555/fake-queue/#{short_path}?template=s3://adventist-preprocess.s3.us-west-1.amazonaws.com/preprocess/#{short_path}" }
+  let(:args) { "sqs://eu-west-1.amazonaws.com/55555555/fake-queue/#{short_path}?template=s3://adventist-preprocess.s3.us-west-1.amazonaws.com/preprocess/{{dir_parts[-1..-1]}}/{{ filename }}" }
   let(:client) { AwsSqsFauxClient.new }
 
   subject { described_class.new(args) }
@@ -47,7 +47,11 @@ RSpec.describe DerivativeRodeo::StorageTargets::SqsTarget do
     # {"https://sqs.us-west-2.amazonaws.com/5555555555/fake"=>[{:id=>"0", :message_body=>"/var/folders/43/3hsph86d56b4mzpzhrbq2fm00000gn/T/d20230510-36732-1civ6nm/ocr_color.tiff"}]}
     expect(client.storage).to be
     expect(client.storage["https://sqs.us-west-2.amazonaws.com/5555555555/fake"].size).to eq(1)
-    expect(client.storage["https://sqs.us-west-2.amazonaws.com/5555555555/fake"].first[:message_body]).to eq('s3://adventist-preprocess.s3.us-west-1.amazonaws.com/preprocess/files/ocr_color.tiff')
+
+    result_body = client.storage["https://sqs.us-west-2.amazonaws.com/5555555555/fake"].first[:message_body]
+    result_json = JSON.parse(result_body)
+    expect(result_json.keys.first).to eq('s3://adventist-preprocess.s3.us-west-1.amazonaws.com/preprocess/files/ocr_color.tiff')
+    expect(result_json.values.first).to eq(['s3://adventist-preprocess.s3.us-west-1.amazonaws.com/preprocess/{{dir_parts[-1..-1]}}/{{ filename }}'])
     expect(File.exist?(@tmp_path)).to be false
   end
 


### PR DESCRIPTION
previously the params template would get filled in by the regexp. we want to preserve its templatyness. Also we want to preserver  the file path in the tmp dir. We need it for other steps.