### PR TITLE
preserve path and filename when splitting pdfs

### DIFF
--- a/lib/derivative_rodeo/generators/hocr_generator.rb
+++ b/lib/derivative_rodeo/generators/hocr_generator.rb
@@ -65,7 +65,8 @@ module DerivativeRodeo
       #
       # @see BaseGenerator#with_each_requisite_target_and_tmp_file_path for further discussion
       def with_each_requisite_target_and_tmp_file_path(builder: MonochromeGenerator)
-        requisite_files ||= builder.new(input_uris: input_uris, output_target_template: output_target_template).generated_files
+        mono_target_template = output_target_template.gsub(self.class.output_extension, builder.output_extension)
+        requisite_files ||= builder.new(input_uris: input_uris, output_target_template: mono_target_template).generated_files
         requisite_files.each do |input_target|
           input_target.with_existing_tmp_path do |tmp_file_path|
             yield(input_target, tmp_file_path)

--- a/lib/derivative_rodeo/generators/pdf_split_generator.rb
+++ b/lib/derivative_rodeo/generators/pdf_split_generator.rb
@@ -48,7 +48,7 @@ module DerivativeRodeo
       def with_each_requisite_target_and_tmp_file_path
         input_files.each do |input_target|
           input_target.with_existing_tmp_path do |input_tmp_file_path|
-            image_paths = pdf_splitter.call(input_tmp_file_path)
+            image_paths = pdf_splitter.call(input_tmp_file_path, baseid: input_target.file_basename, tmpdir: File.dirname(input_tmp_file_path))
             image_paths.each do |image_path|
               image_target = StorageTargets::FileTarget.new("file://#{image_path}")
               yield(image_target, image_path)

--- a/lib/derivative_rodeo/services/pdf_splitter/base.rb
+++ b/lib/derivative_rodeo/services/pdf_splitter/base.rb
@@ -37,8 +37,8 @@ module DerivativeRodeo
         # @param path [String] The path the the PDF
         #
         # @return [Enumerable, Utilities::PdfSplitter::Base]
-        def self.call(path)
-          new(path)
+        def self.call(path, baseid: SureRandom.uuid, tmpdir: Dir.mktmpdir)
+          new(path, baseid: baseid, tmpdir: tmpdir)
         end
 
         ##
@@ -104,7 +104,7 @@ module DerivativeRodeo
           file_names = []
 
           Open3.popen3(gsconvert_cmd(output_base)) do |_stdin, stdout, _stderr, _wait_thr|
-            page_number = 0
+            page_number = 1
             stdout.read.split("\n").each do |line|
               next unless line.start_with?('Page ')
 

--- a/lib/derivative_rodeo/storage_targets/base_target.rb
+++ b/lib/derivative_rodeo/storage_targets/base_target.rb
@@ -157,7 +157,8 @@ module DerivativeRodeo
         raise ArgumentError, 'Expected a block' unless block_given?
 
         tmp_file_dir do |tmpdir|
-          self.tmp_file_path = File.join(tmpdir, file_name)
+          self.tmp_file_path = File.join(tmpdir, file_dir, file_name)
+          FileUtils.mkdir_p(File.dirname(tmp_file_path))
           preamble_lambda.call(file_path, tmp_file_path, exist?)
           yield tmp_file_path
           write if auto_write_file
@@ -215,6 +216,14 @@ module DerivativeRodeo
 
       def file_name
         @file_name ||= File.basename(file_path)
+      end
+
+      def file_extension
+        @file_extension ||= File.extname(file_path)
+      end
+
+      def file_basename
+        @file_basename ||= File.basename(file_path, file_extension)
       end
 
       def tmp_file_dir(&block)

--- a/spec/derivative_rodeo/generators/hocr_generator_spec.rb
+++ b/spec/derivative_rodeo/generators/hocr_generator_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe DerivativeRodeo::Generators::HocrGenerator do
         generated_files = nil
         Fixtures.with_file_uris_for("ocr_color.tiff") do |input_uris|
           Fixtures.with_temporary_directory do |output_temporary_path|
-            output_target_template = "file://#{output_temporary_path}/{{ dir_parts[0..-1] }}/{{basename}}.#{described_class.output_extension}"
+            output_target_template = "file://#{output_temporary_path}/{{ dir_parts[-1..-1] }}/{{basename}}.#{described_class.output_extension}"
             instance = described_class.new(input_uris: input_uris, output_target_template: output_target_template)
             generated_files = instance.generated_files
 
@@ -38,7 +38,7 @@ RSpec.describe DerivativeRodeo::Generators::HocrGenerator do
         generated_files = nil
         Fixtures.with_file_uris_for('ocr_color_pre.tiff') do |input_uris|
           Fixtures.with_temporary_directory do |output_temporary_path|
-            output_target_template = "file://#{output_temporary_path}/{{ dir_parts[0..-1] }}/{{basename}}.#{described_class.output_extension}"
+            output_target_template = "file://#{output_temporary_path}/{{ dir_parts[-1..-1] }}/{{basename}}.#{described_class.output_extension}"
             instance = described_class.new(input_uris: input_uris, output_target_template: output_target_template)
             generated_files = instance.generated_files
 

--- a/spec/derivative_rodeo/storage_targets/sqs_target_spec.rb
+++ b/spec/derivative_rodeo/storage_targets/sqs_target_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe DerivativeRodeo::StorageTargets::SqsTarget do
   let(:file_path) { File.expand_path(File.join(FIXTURE_PATH, 'files', 'ocr_color.tiff')) }
   let(:short_path) { file_path.split('/')[-2..-1].join('/') }
-  let(:args) { "sqs://eu-west-1.amazonaws.com/55555555/fake-queue/#{short_path}?template=s3://adventist-preprocess.s3.us-west-1.amazonaws.com/preprocess/#{short_path}" }
+  let(:args) { "sqs://eu-west-1.amazonaws.com/55555555/fake-queue/#{short_path}?template=s3://adventist-preprocess.s3.us-west-1.amazonaws.com/preprocess/{{dir_parts[-1..-1]}}/{{ filename }}" }
   let(:client) { AwsSqsFauxClient.new }
 
   subject { described_class.new(args) }
@@ -47,7 +47,11 @@ RSpec.describe DerivativeRodeo::StorageTargets::SqsTarget do
     # {"https://sqs.us-west-2.amazonaws.com/5555555555/fake"=>[{:id=>"0", :message_body=>"/var/folders/43/3hsph86d56b4mzpzhrbq2fm00000gn/T/d20230510-36732-1civ6nm/ocr_color.tiff"}]}
     expect(client.storage).to be
     expect(client.storage["https://sqs.us-west-2.amazonaws.com/5555555555/fake"].size).to eq(1)
-    expect(client.storage["https://sqs.us-west-2.amazonaws.com/5555555555/fake"].first[:message_body]).to eq('s3://adventist-preprocess.s3.us-west-1.amazonaws.com/preprocess/files/ocr_color.tiff')
+
+    result_body = client.storage["https://sqs.us-west-2.amazonaws.com/5555555555/fake"].first[:message_body]
+    result_json = JSON.parse(result_body)
+    expect(result_json.keys.first).to eq('s3://adventist-preprocess.s3.us-west-1.amazonaws.com/preprocess/files/ocr_color.tiff')
+    expect(result_json.values.first).to eq(['s3://adventist-preprocess.s3.us-west-1.amazonaws.com/preprocess/{{dir_parts[-1..-1]}}/{{ filename }}'])
     expect(File.exist?(@tmp_path)).to be false
   end
 


### PR DESCRIPTION
`TMPDIR/path/MyFile.pdf` becomes `TMPDIR/path/MyFile-page1.pdf`. 

Also page count starts at 1 not 0.