### PR TITLE
♻️ Allowing input_uris to be singular

### DIFF
--- a/lib/derivative_rodeo/generators/base_generator.rb
+++ b/lib/derivative_rodeo/generators/base_generator.rb
@@ -41,7 +41,7 @@ module DerivativeRodeo
       #        :preprocessed_location_template.
       # @param logger [Logger]
       def initialize(input_uris:, output_location_template:, preprocessed_location_template: nil, logger: DerivativeRodeo.config.logger)
-        @input_uris = input_uris
+        @input_uris = Array.wrap(input_uris)
         @output_location_template = output_location_template
         @preprocessed_location_template = preprocessed_location_template
         @logger = logger

--- a/spec/derivative_rodeo/generators/base_generator_spec.rb
+++ b/spec/derivative_rodeo/generators/base_generator_spec.rb
@@ -10,6 +10,22 @@ RSpec.describe DerivativeRodeo::Generators::BaseGenerator do
 
   its(:output_extension) { is_expected.to be_nil }
 
+  describe '#input_uris' do
+    subject { instance.input_uris }
+    context 'when given a String' do
+      let(:kwargs) { { input_uris: '123', output_location_template: "" } }
+      it { is_expected.to be_a(Array) }
+    end
+
+    context 'when given an Array' do
+      let(:kwargs) { { input_uris: ['123'], output_location_template: "" } }
+
+      it "uses the given array" do
+        expect(subject).to match_array(kwargs.fetch(:input_uris))
+      end
+    end
+  end
+
   describe '#build_step' do
     it 'must be defined by a child class' do
       expect { subject.build_step(input_location: nil, output_location: nil, input_tmp_file_path: nil) }.to raise_error(NotImplementedError)


### PR DESCRIPTION
In the SpaceStone implementation, I'm noticing that we sometimes have multiple URIs and other times singular.  By favoring the `Array.wrap` we're accepting either one and casting them to an Array.