### PR TITLE
🎁 WIP - Adding Thumbnail Generator skeleton

### DIFF
--- a/lib/derivative_rodeo/generators/thumbnail_generator.rb
+++ b/lib/derivative_rodeo/generators/thumbnail_generator.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module DerivativeRodeo
+  module Generators
+    ##
+    # This generator is responsible for converting a given binary into a thumbnail.  As of
+    # <2023-05-22 Mon>, we're needing to generate thumbnails for PDFs and images.
+    class ThumbnailGenerator < BaseGenerator
+      ##
+      # We want to mirror the same file "last" extension as described in Hyrax.
+      #
+      # @see https://github.com/samvera/hyrax/blob/426575a9065a5dd3b30f458f5589a0a705ad7be2/app/services/hyrax/file_set_derivatives_service.rb
+      self.output_extension = 'thumbnail.jpg'
+
+      ##
+      # @param output_location [StorageLocations::BaseLocation]
+      # @param input_tmp_file_path [String] the location of the file that we can use for processing.
+      #
+      # @return [StorageLocations::BaseLocation]
+      def build_step(output_location:, input_tmp_file_path:, **)
+        output_location.with_new_tmp_path do |out_tmp_path|
+          thumbnify(path_of_file_to_create_thumbnail_from: input_tmp_file_path, path_for_thumbnail_output: out_tmp_path)
+        end
+      end
+
+      ##
+      # Convert the file found at :path_to_input into a thumbnail, writing it to the
+      # :path_for_thumbnail_output
+      #
+      # @param path_of_file_to_create_thumbnail_from [String]
+      # @param path_for_thumbnail_output [String]
+      def thumbnify(path_of_file_to_create_thumbnail_from:, path_for_thumbnail_output:)
+        # Put a byebug here is reasonable.
+        # Favor and if possible, call the command line tools without any MiniMagick
+        # TODO: Do the command-line
+        raise NotImplementedError, "Kirk and Deon will be implementing this!"
+      end
+    end
+  end
+end

--- a/spec/derivative_rodeo/generators/thumbnail_generator_spec.rb
+++ b/spec/derivative_rodeo/generators/thumbnail_generator_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe DerivativeRodeo::Generators::ThumbnailGenerator do
+  context '.output_extension' do
+    subject { described_class.output_extension }
+    it { is_expected.to eq("thumbnail.jpg") }
+  end
+
+  describe "#generated_files" do
+    context 'for a PDF' do
+      xit 'creates a thumbnail.jpg file' do
+        generated_file = nil
+        Fixtures.with_file_uris_for("minimal-2-page.pdf") do |pdf_uris, from_tmp_dir|
+          template = "file://#{from_tmp_dir}/{{ basename }}.{{ extension }}"
+          instance = described_class.new(input_uris: pdf_uris, output_location_template: template)
+          generated_file = instance.generated_files.first
+
+          expect(generated_file.exist?).to be_truthy
+        end
+
+        expect(generated_file.exist?).to be_falsey
+      end
+    end
+
+    context 'for an Image' do
+      xit 'creates a thumbnail.jpg file' do
+        generated_file = nil
+        Fixtures.with_file_uris_for("4.1.07.tiff") do |tiff_uris, from_tmp_dir|
+          template = "file://#{from_tmp_dir}/{{ basename }}.{{ extension }}"
+          instance = described_class.new(input_uris: tiff_uris, output_location_template: template)
+          generated_file = instance.generated_files.first
+
+          # generated_file.file_path is where the thumbnail will be within the Fixtures block; once
+          # the block closes, that thumbnail is cleaned up.
+          # Put a byebug here is reasonable.
+          expect(generated_file.exist?).to be_truthy
+        end
+
+        expect(generated_file.exist?).to be_falsey
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit introduces the skeleton of the thumbnail generation necessary for PDFs, images, and the images that we make from the PDFs.

It does not have the full business logic to perform this work; but the specs are mostly in place and can then be used to drive development.

Related to #22

- https://github.com/scientist-softserv/derivative_rodeo/issues/22