### PR TITLE
♻️ Replacing Faraday with Httparty

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,8 +5,6 @@ PATH
       activesupport (>= 5)
       aws-sdk-s3
       aws-sdk-sqs
-      faraday
-      faraday-follow_redirects
       httparty
       marcel
       mime-types
@@ -54,12 +52,6 @@ GEM
     diff-lcs (1.5.0)
     docile (1.4.0)
     e2mmap (0.1.0)
-    faraday (2.7.4)
-      faraday-net_http (>= 2.0, < 3.1)
-      ruby2_keywords (>= 0.0.4)
-    faraday-follow_redirects (0.3.0)
-      faraday (>= 1, < 3)
-    faraday-net_http (3.0.2)
     httparty (0.21.0)
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
@@ -131,7 +123,6 @@ GEM
     rubocop-rspec (2.11.1)
       rubocop (~> 1.19)
     ruby-progressbar (1.13.0)
-    ruby2_keywords (0.0.5)
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
     simplecov (0.22.0)

--- a/derivative_rodeo.gemspec
+++ b/derivative_rodeo.gemspec
@@ -32,8 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport', '>= 5'
   spec.add_dependency 'aws-sdk-s3'
   spec.add_dependency 'aws-sdk-sqs'
-  spec.add_dependency 'faraday'
-  spec.add_dependency 'faraday-follow_redirects'
   spec.add_dependency 'httparty'
   spec.add_dependency 'marcel'
   spec.add_dependency 'mime-types'


### PR DESCRIPTION
> Many versions of Valkyrie and ActiveFedora have Faraday `~> 0.9` type
> dependencies whereas the Faraday redirect middleware requires Faraday
> `~> 1.0` or some such thing.

Updating Valkyrie and ActiveFedora's different branches and versions to later Faraday versions.

Closes #31

- https://github.com/scientist-softserv/derivative_rodeo/issues/31