### PR TITLE
♻️ Improving Legibility of PDF Splitting

### DIFF
--- a/lib/derivative_rodeo.rb
+++ b/lib/derivative_rodeo.rb
@@ -33,4 +33,8 @@ module DerivativeRodeo
     yield(@config) if block_given?
     @config
   end
+
+  class << self
+    delegate :logger, to: :config
+  end
 end

--- a/spec/derivative_rodeo/generators/pdf_split_generator_spec.rb
+++ b/spec/derivative_rodeo/generators/pdf_split_generator_spec.rb
@@ -14,13 +14,6 @@ RSpec.describe DerivativeRodeo::Generators::PdfSplitGenerator do
 
   context 'by default' do
     its(:output_extension) { is_expected.to eq('tiff') }
-    its(:pdf_splitter_name) { is_expected.to eq(:tiff) }
-  end
-
-  context 'when you change the #output_extension' do
-    it 'changes the #pdf_splitter_name' do
-      expect { instance.output_extension = 'png' }.to change(instance, :pdf_splitter_name).from(:tiff).to(:png)
-    end
   end
 
   describe '#generated_files' do
@@ -29,7 +22,7 @@ RSpec.describe DerivativeRodeo::Generators::PdfSplitGenerator do
         generated_files = nil
         Fixtures.with_file_uris_for("minimal-2-page.pdf") do |input_uris|
           Fixtures.with_temporary_directory do |output_temporary_path|
-            output_location_template = "file://#{output_temporary_path}/{{dir_parts[0..-1]}}/{{ filename }}"
+            output_location_template = "file://#{output_temporary_path}/{{dir_parts[-1..-1]}}/{{ filename }}"
             instance = described_class.new(input_uris: input_uris, output_location_template: output_location_template)
             generated_files = instance.generated_files
 

--- a/spec/derivative_rodeo/services/pdf_splitter/base_spec.rb
+++ b/spec/derivative_rodeo/services/pdf_splitter/base_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 RSpec.describe DerivativeRodeo::Services::PdfSplitter::Base do
-  subject { described_class.new(__FILE__, pdf_pages_summary: pdf_pages_summary) }
+  subject { described_class.new(__FILE__, pdf_pages_summary: pdf_pages_summary, image_file_basename_template: "%d") }
   let(:pdf_pages_summary) { double(DerivativeRodeo::Services::PdfSplitter::PagesSummary) }
 
   # Becasue the described class is an abstract class, we want to verify its public interface.

--- a/spec/derivative_rodeo_spec.rb
+++ b/spec/derivative_rodeo_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe DerivativeRodeo do
     expect(DerivativeRodeo::VERSION).not_to be nil
   end
 
-  it 'loads a configuration object' do
-    expect(subject.config).to be_a DerivativeRodeo::Configuration
-  end
+  its(:config) { is_expected.to be_a DerivativeRodeo::Configuration }
+  its(:logger) { is_expected.to be_a Logger }
 end


### PR DESCRIPTION
As part of working on #219, I was looking into "What is the pathing convention for the split images?"  As I was reading the code to get to that answer, I realized that I wanted to see that information in the `DerivativeRodeo::Generators::PdfSplitGenerator`.

Further, given that the PdfSplitGenerator is part of the more visible "interface" of the DerivativeRodeo, I think it is important for the filename to be present.

Thus I moved towards this refactor, to better expose that and remove additional chatter in the code.  There are still a few things remaining but this has helped re-inforce my understanding of the PDF Splitting.

I could further "compress" the basename template concept into the fully qualitified filename; but I think that would confuse concepts.

Related to:

- https://github.com/scientist-softserv/iiif_print/issues/219