### PR TITLE
🎁 Add plain text generator

### DIFF
--- a/lib/derivative_rodeo/generators/plain_text_generator.rb
+++ b/lib/derivative_rodeo/generators/plain_text_generator.rb
@@ -6,8 +6,8 @@ module DerivativeRodeo
     # Generate the word coordinates (as JSON) from the given input_uris.
     #
     # @note Assumes that we're receiving a HOCR file (generated via {HocrGenerator}).
-    class WordCoordinatesGenerator < BaseGenerator
-      self.output_extension = "coordinates.json"
+    class PlainTextGenerator < BaseGenerator
+      self.output_extension = "plain_text.txt"
 
       ##
       # @param output_location [StorageLocations::BaseLocation]
@@ -18,7 +18,7 @@ module DerivativeRodeo
       # @see #requisite_files
       def build_step(output_location:, input_tmp_file_path:, **)
         output_location.with_new_tmp_path do |output_tmp_file_path|
-          convert_to_coordinates(path_to_hocr: input_tmp_file_path, path_to_coordinate: output_tmp_file_path)
+          convert_to_coordinates(path_to_hocr: input_tmp_file_path, path_to_plain_text: output_tmp_file_path)
         end
       end
 
@@ -26,12 +26,12 @@ module DerivativeRodeo
 
       ##
       # @param path_to_hocr [String]
-      # @param path_to_coordinate [String]
+      # @param path_to_plain_text [String]
       # @param service [#call, Services::ExtractWordCoordinatesFromHocrSgmlService]
-      def convert_to_coordinates(path_to_hocr:, path_to_coordinate:, service: Services::ExtractWordCoordinatesFromHocrSgmlService)
+      def convert_to_coordinates(path_to_hocr:, path_to_plain_text:, service: Services::ExtractWordCoordinatesFromHocrSgmlService)
         hocr_html = File.read(path_to_hocr)
-        File.open(path_to_coordinate, "w+") do |file|
-          file.puts service.call(hocr_html).to_json
+        File.open(path_to_plain_text, "w+") do |file|
+          file.puts service.call(hocr_html).to_text
         end
       end
     end

--- a/lib/derivative_rodeo/services/extract_word_coordinates_from_hocr_sgml_service.rb
+++ b/lib/derivative_rodeo/services/extract_word_coordinates_from_hocr_sgml_service.rb
@@ -13,7 +13,7 @@ module DerivativeRodeo
       # @param sgml [String] The SGML (e.g. XML or HTML) text of a HOCR file.
       # @return [String] A JSON document
       def self.call(sgml)
-        new(sgml).to_json
+        new(sgml)
       end
 
       ##
@@ -41,6 +41,13 @@ module DerivativeRodeo
         )
       end
       alias json to_json
+
+      # Output plain text, keeping the method calls consistent with so calling this #to_text
+      #
+      # @return [String] plain text of OCR'd document
+      def to_text
+        @to_text ||= doc_stream.text
+      end
 
       private
 

--- a/spec/derivative_rodeo/generators/plain_text_generator_spec.rb
+++ b/spec/derivative_rodeo/generators/plain_text_generator_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe DerivativeRodeo::Generators::PlainTextGenerator do
+  describe "#generated_files" do
+    it "derives the plain text from the given hocr file" do
+      generated_file = nil
+      Fixtures.with_file_uris_for("ocr_mono_text_hocr.html") do |hocr_uris, from_tmp_dir|
+        template = "file://#{from_tmp_dir}/{{ basename }}.plain_text.txt"
+        instance = described_class.new(input_uris: hocr_uris, output_location_template: template)
+        generated_file = instance.generated_files.first
+        text = File.read(generated_file.file_path)
+        expect(generated_file.exist?).to be_truthy
+        expect(generated_file.file_path).to end_with("/ocr_mono_text_hocr.plain_text.txt")
+        expect(text.lines.size).to eq 19
+        expect(text.lines.first).to eq "_A FEARFUL ADVENTURE.\n"
+      end
+
+      expect(generated_file.exist?).to be_falsey
+    end
+  end
+end


### PR DESCRIPTION
This commit will add a plain text generator.  This also moves the `to_json` so it is not initialized and uses the same pattern to make the `to_text` method.

- Ref: https://github.com/scientist-softserv/derivative_rodeo/issues/27