### PR TITLE
🐛 Fixing the DownloadConcern to match location interface

### DIFF
--- a/lib/derivative_rodeo/storage_locations/concerns/download_concern.rb
+++ b/lib/derivative_rodeo/storage_locations/concerns/download_concern.rb
@@ -43,7 +43,7 @@ module DerivativeRodeo
       # @param url [String]
       #
       # @return [String]
-      def read(url)
+      def get(url)
         HTTParty.get(url, logger: config.logger)
       rescue => e
         config.logger.error(%(#{e.message}\n#{e.backtrace.join("\n")}))
@@ -51,13 +51,11 @@ module DerivativeRodeo
       end
 
       ##
-      # @param url [String]
-      #
       # @return [URI] when the URL resolves successfully
       # @return [FalseClass] when the URL's head request is not successful or we've exhausted our
       #         remaining redirects.
-      def exists?(url)
-        HTTParty.head(url, logger: config.logger)
+      def exist?
+        HTTParty.head(file_uri, logger: config.logger)
       rescue => e
         config.logger.error(%(#{e.message}\n#{e.backtrace.join("\n")}))
         false


### PR DESCRIPTION
The prior implementation was copied from the dash rodeo, which leveraged Httparty and had a different interface.  The reason for the copy is that we previously used Faraday, but had version conflicts.

Related to:

- https://github.com/scientist-softserv/derivative_rodeo/pull/32