### PR TITLE
♻️ Exposing ability to pass bucket name to prefix

### DIFF
--- a/lib/derivative_rodeo/storage_locations/base_location.rb
+++ b/lib/derivative_rodeo/storage_locations/base_location.rb
@@ -42,6 +42,8 @@ module DerivativeRodeo
 
       class << self
         alias scheme location_name
+
+        delegate :config, to: DerivativeRodeo
       end
 
       ##

--- a/lib/derivative_rodeo/storage_locations/s3_location.rb
+++ b/lib/derivative_rodeo/storage_locations/s3_location.rb
@@ -32,10 +32,11 @@ module DerivativeRodeo
       end
 
       ##
-      # @param config [DerivativeRodeo::Configuration]
+      # @param bucket_name [String, NilClass] when given, use this as the bucket, otherwise, def
+      #
       # @return [String]
-      def self.adapter_prefix(config: DerivativeRodeo.config)
-        "#{scheme}://#{config.aws_s3_bucket}.s3.#{config.aws_s3_region}.amazonaws.com"
+      def self.adapter_prefix(bucket_name: config.aws_s3_bucket)
+        "#{scheme}://#{bucket_name}.s3.#{config.aws_s3_region}.amazonaws.com"
       end
 
       ##

--- a/spec/derivative_rodeo/storage_locations/base_location_spec.rb
+++ b/spec/derivative_rodeo/storage_locations/base_location_spec.rb
@@ -11,6 +11,11 @@ RSpec.describe DerivativeRodeo::StorageLocations::BaseLocation do
     expect { described_class.new }.to raise_error(ArgumentError)
   end
 
+  context 'class methods' do
+    subject { described_class }
+    its(:config) { is_expected.to be_a(DerivativeRodeo::Configuration) }
+  end
+
   its(:config) { is_expected.to be_a(DerivativeRodeo::Configuration) }
 
   it "should set the file_uri on initialize" do

--- a/spec/derivative_rodeo/storage_locations/s3_location_spec.rb
+++ b/spec/derivative_rodeo/storage_locations/s3_location_spec.rb
@@ -5,16 +5,34 @@ RSpec.describe DerivativeRodeo::StorageLocations::S3Location do
   let(:short_path) { file_path.split('/')[-2..-1].join('/') }
   let(:args) { "s3://fake-bucket.s3.eu-west-1.amazonaws.com/#{short_path}" }
 
-  subject { described_class.new(args) }
+  subject(:instance) { described_class.new(args) }
 
   before do
     # Let's use a FakeBucket instead!
-    subject.use_actual_s3_bucket = false
+    instance.use_actual_s3_bucket = false
 
     DerivativeRodeo.config do |config|
       config.aws_s3_bucket = 'fake-bucket'
       config.aws_s3_access_key_id = "FAKEFAKEFAKE"
       config.aws_s3_secret_access_key = "FAKEFAKEFAKEFAKER"
+    end
+  end
+
+  context '.adapter_prefix' do
+    context 'when no bucket is given' do
+      subject { described_class.adapter_prefix }
+
+      it 'uses the default config.aws_s3_bucket' do
+        expect(subject).to eq("s3://fake-bucket.s3.us-east-1.amazonaws.com")
+      end
+    end
+
+    context 'when given a bucket' do
+      subject { described_class.adapter_prefix(bucket_name: "wonky-tonky") }
+
+      it 'uses the given bucket_name' do
+        expect(subject).to eq("s3://wonky-tonky.s3.us-east-1.amazonaws.com")
+      end
     end
   end
 


### PR DESCRIPTION
This is meant to a means of removing duplication of knowledge between some very specific SpaceStone details and the details necessary for IIIF Print to have a chance at using the same configuration/convention.

This is informed by the logic at the following two place in SpaceStone::Serverless:

https://github.com/scientist-softserv/space_stone-serverless/blob/7f46dd5b218381739cd1c771183f95408a4e0752/awslambda/handler.rb#L58

https://github.com/scientist-softserv/space_stone-serverless/blob/7f46dd5b218381739cd1c771183f95408a4e0752/awslambda/handler.rb#L197-L199