### PR TITLE
🎁 Exposing a method to answer "was this a split file" 

### DIFF
--- a/lib/derivative_rodeo/generators/pdf_split_generator.rb
+++ b/lib/derivative_rodeo/generators/pdf_split_generator.rb
@@ -17,6 +17,27 @@ module DerivativeRodeo
       include CopyFileConcern
 
       ##
+      # A helper method for downstream implementations to ask if this file is perhaps split from a
+      # PDF.
+      #
+      # @param filename [String]
+      # @param extension [String] the extension (either with or without the leading period); if none
+      #        is provided use the extension of the given :filename.
+      # @return [TrueClass] when the file name likely represents a file split from a PDF.
+      # @return [FalseClass] when the file name does not, by convention, represent a file split from
+      #         a PDF.
+      #
+      # @see #image_file_basename_template
+      def self.filename_for_a_derived_page_from_a_pdf?(filename:, extension: nil)
+        extension ||= File.extname(filename)
+
+        # Strip the leading period from the extension.
+        extension = extension[1..-1] if extension.start_with?('.')
+        regexp = %r{--page-\d+\.#{extension}$}
+        !!regexp.match(filename)
+      end
+
+      ##
       # @param basename [String] The given PDF file's base name (e.g. "hello.pdf" would have a base name of
       #        "hello").
       #
@@ -29,6 +50,7 @@ module DerivativeRodeo
       # each split image.  Further there is an interaction in this
       #
       # @see #existing_page_locations
+      # @see .filename_for_a_derived_page_from_a_pdf?
       def image_file_basename_template(basename:)
         "#{basename}/pages/#{basename}--page-%d.#{output_extension}"
       end

--- a/lib/derivative_rodeo/generators/pdf_split_generator.rb
+++ b/lib/derivative_rodeo/generators/pdf_split_generator.rb
@@ -30,7 +30,7 @@ module DerivativeRodeo
       #
       # @see #existing_page_locations
       def image_file_basename_template(basename:)
-        "#{basename}/pages/#{basename}-%d.#{output_extension}"
+        "#{basename}/pages/#{basename}--page-%d.#{output_extension}"
       end
 
       ##

--- a/spec/derivative_rodeo/generators/pdf_split_generator_spec.rb
+++ b/spec/derivative_rodeo/generators/pdf_split_generator_spec.rb
@@ -16,6 +16,24 @@ RSpec.describe DerivativeRodeo::Generators::PdfSplitGenerator do
     its(:output_extension) { is_expected.to eq('tiff') }
   end
 
+  describe '.filename_for_a_derived_page_from_a_pdf?' do
+    subject { described_class.filename_for_a_derived_page_from_a_pdf?(filename: filename, extension: extension) }
+    [
+      ["hello--page-a.tiff", 'tiff', false],
+      ["hello--page-1.tiff", nil, true], # It uses filename's extension
+      ["hello--page-1.tiff", '.tiff', true],
+      ["hello-page-1.tiff", '.tiff', false], # Does not have leading double dash
+      ["hello--page-1.png", '.tiff', false], # Wrong file extension
+      ["hello--page-1.tiffany", '.tiff', false] # Additional words at end of filename
+    ].each do |given_filename, given_extension, expected_result|
+      context "for filename: #{given_filename.inspect} and extension: #{given_extension.inspect}" do
+        let(:filename) { given_filename }
+        let(:extension) { given_extension }
+        it { is_expected.to eq(expected_result) }
+      end
+    end
+  end
+
   describe '#generated_files' do
     context 'when given an already split PDF' do
       it 'uses the already split components' do


### PR DESCRIPTION
## 🎁 Updating format of split pages

As I'm working on IIIF print and how to detect a split, I want a bit
more options for detecting that split.

This should provide adequate options.

## 🎁 Exposing a method to answer "was this a split file" 

Without this feature, we're asking downstream implementations to answer
if this was a split file or not.

There's still some assumptions but this helps clarify and reduce
assumptions that downstream implementations need make.
