### PR TITLE
⚙️ Bumping to version 0.3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    derivative-rodeo (0.2.0)
+    derivative-rodeo (0.3.0)
       activesupport (>= 5)
       aws-sdk-s3
       aws-sdk-sqs
@@ -21,8 +21,8 @@ GEM
       tzinfo (~> 2.0)
     ast (2.4.2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.763.0)
-    aws-sdk-core (3.172.0)
+    aws-partitions (1.772.0)
+    aws-sdk-core (3.173.1)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.651.0)
       aws-sigv4 (~> 1.5)

--- a/lib/derivative_rodeo/version.rb
+++ b/lib/derivative_rodeo/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DerivativeRodeo
-  VERSION = '0.2.0'
+  VERSION = '0.3.0'
 end


### PR DESCRIPTION
This change brings a few underlying public methods for downstream to use.

Why the minor version?  Any changes prior to 1.0 are volatile and versions don't quite matter.