### PR TITLE
♻️ Flattening assumptive dir structure for PDFs

### DIFF
--- a/lib/derivative_rodeo/generators/base_generator.rb
+++ b/lib/derivative_rodeo/generators/base_generator.rb
@@ -39,7 +39,6 @@ module DerivativeRodeo
       #        {Services::ConvertUriViaTemplateService} with the given
       #        :preprocessed_location_template.
       def initialize(input_uris:, output_location_template:, preprocessed_location_template: nil)
-        # NOTE: Are we using this preprocessed_location_template?  Wondering?
         @input_uris = Array.wrap(input_uris)
         @output_location_template = output_location_template
         @preprocessed_location_template = preprocessed_location_template

--- a/lib/derivative_rodeo/storage_locations/base_location.rb
+++ b/lib/derivative_rodeo/storage_locations/base_location.rb
@@ -210,18 +210,18 @@ module DerivativeRodeo
 
       ##
       # When you have a known location and want to check for files that are within that location,
-      # use the {#globbed_tail_locations} method.  In the case of {Generators::PdfSplitGenerator} we
+      # use the {#matching_locations_in_file_dir} method.  In the case of {Generators::PdfSplitGenerator} we
       # need to know the path to all of the image files we "split" off of the given PDF.
       #
       # We can use the :file_path as the prefix the given :tail_glob as the suffix for a "fully
       # qualified" Dir.glob type search.
       #
-      # @param tail_glob [String]
+      # @param tail_regexp [Regexp]
       #
       # @return [Enumerable<StorageLocations::BaseLocation>] the locations of the files; an empty
       #         array when there are none.
-      def globbed_tail_locations(tail_glob:)
-        raise NotImplementedError, "#{self.class}#globbed_locations"
+      def matching_locations_in_file_dir(tail_regexp:)
+        raise NotImplementedError, "#{self.class}#matching_locations_in_file_dir"
       end
 
       ##

--- a/lib/derivative_rodeo/storage_locations/file_location.rb
+++ b/lib/derivative_rodeo/storage_locations/file_location.rb
@@ -35,8 +35,16 @@ module DerivativeRodeo
         file_uri
       end
 
-      def globbed_tail_locations(tail_glob:)
-        Dir.glob(File.join(file_dir, tail_glob))
+      ##
+      # @return [Enumerable<DerivativeRodeo::StorageLocations::FileLocation>]
+      #
+      # @see Generators::PdfSplitGenerator#image_file_basename_template
+      #
+      # @param tail_regexp [Regexp]
+      def matching_locations_in_file_dir(tail_regexp:)
+        Dir.glob(File.join(file_dir, "*")).each_with_object([]) do |filename, accumulator|
+          accumulator << derived_file_from(template: "file://#{filename}") if tail_regexp.match(filename)
+        end
       end
     end
   end

--- a/spec/derivative_rodeo/generators/pdf_split_generator_spec.rb
+++ b/spec/derivative_rodeo/generators/pdf_split_generator_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe DerivativeRodeo::Generators::PdfSplitGenerator do
             output_location = DerivativeRodeo::StorageLocations::FileLocation.build(from_uri: input_uris.first, template: output_location_template)
 
             # Let's fake a nice TIFF being in a pre-processed location.
-            pre_existing_tiff_path = File.join(output_location.file_dir, output_location.file_basename, "pages/1.tiff")
+            pre_existing_tiff_path = File.join(output_location.file_dir, "#{output_location.file_basename}--page-1.tiff")
             FileUtils.mkdir_p(File.dirname(pre_existing_tiff_path))
             File.open(pre_existing_tiff_path, "w+") do |f|
               f.puts "🤠🐮🐴 A muppet man parading as a TIFF."

--- a/spec/derivative_rodeo/storage_locations/file_location_spec.rb
+++ b/spec/derivative_rodeo/storage_locations/file_location_spec.rb
@@ -69,11 +69,13 @@ RSpec.describe DerivativeRodeo::StorageLocations::FileLocation do
   end
   xit "write cases or mark private the rest of the methods"
 
-  context '#globbed_tail_locations' do
+  context '#matching_locations_in_file_dir' do
     let(:args) { "file://#{__FILE__}" }
 
     it "searches for files within the file_dir that match the given glob" do
-      expect(instance.globbed_tail_locations(tail_glob: "*.rb")).to include(__FILE__)
+      locations = instance.matching_locations_in_file_dir(tail_regexp: %r{file_location_spec\.rb$})
+      expect(locations.size).to eq(1)
+      expect(locations.map(&:file_name)).to match_array([File.basename(__FILE__)])
     end
   end
 end

--- a/spec/derivative_rodeo/storage_locations/s3_location_spec.rb
+++ b/spec/derivative_rodeo/storage_locations/s3_location_spec.rb
@@ -83,22 +83,22 @@ RSpec.describe DerivativeRodeo::StorageLocations::S3Location do
   xit "write additional write cases"
   xit "write cases or mark private the rest of the methods"
 
-  describe '#globbed_tail_locations' do
+  describe '#matching_locations_in_file_dir' do
     it 'searched the bucket' do
       # Because we instantiated the subject as a location to the :file_path (e.g. let(:file_path))
       # we are encoding where things are relative to this file.  In other words, this logic is
       # mirroring the generator logic that says where we're writing derivatives relative to their
       # original file/input file.
-      bucket_dir = "files/#{File.basename(file_path, '.tiff')}"
+      bucket_dir = "files"
 
-      basename = File.basename(__FILE__)
-      key = File.join(bucket_dir, "pages", basename)
+      original_basename_no_ext = File.basename(file_path, '.tiff')
+      key = File.join(bucket_dir, "#{original_basename_no_ext}--page-1.tiff")
       subject.bucket.object(key).upload_file(__FILE__)
 
-      non_matching_key = File.join(bucket_dir, "missing", basename)
+      non_matching_key = File.join(bucket_dir, "#{original_basename_no_ext}-skip--page-1.tiff")
       subject.bucket.object(non_matching_key).upload_file(__FILE__)
 
-      locations = subject.globbed_tail_locations(tail_glob: "ocr_color/pages/*.rb")
+      locations = subject.matching_locations_in_file_dir(tail_regexp: %r{#{original_basename_no_ext}--page-\d+\.tiff$})
 
       expect(locations.size).to eq(1)
     end


### PR DESCRIPTION
Yes, it would be nice to have sub-directories for pages ripped from a PDF.  However, that aspirational state creates complications on the implementation details of the DerivativeRodeo; by moving from a tail glob to a regular expression, we create a more powerful mechanism for finding files.

These changes also highlighted a few implementation bugs (namely ensuring the correct expected return value of the newly re-named function).

In IIIF Print we still need to consider how to find the child page's derivatives of an original PDF.  That is, however, not a problem for this repository.

Related to:

- https://github.com/scientist-softserv/iiif_print/issues/251