### PR TITLE
🐛 Exposing means for generator to specify output extension

### DIFF
--- a/lib/derivative_rodeo/generators/base_generator.rb
+++ b/lib/derivative_rodeo/generators/base_generator.rb
@@ -168,12 +168,12 @@ module DerivativeRodeo
       #
       # @see [StorageLocations::BaseLocation#exist?]
       def destination(input_location)
-        output_location = input_location.derived_file_from(template: output_location_template)
+        output_location = input_location.derived_file_from(template: output_location_template, extension: output_extension)
 
         return output_location if output_location.exist?
         return output_location unless preprocessed_location_template
 
-        preprocessed_location = input_location.derived_file_from(template: preprocessed_location_template)
+        preprocessed_location = input_location.derived_file_from(template: preprocessed_location_template, extension: output_extension)
         # We only want the location if it exists
         return preprocessed_location if preprocessed_location&.exist?
 

--- a/lib/derivative_rodeo/services/convert_uri_via_template_service.rb
+++ b/lib/derivative_rodeo/services/convert_uri_via_template_service.rb
@@ -46,11 +46,11 @@ module DerivativeRodeo
       #     from_uris: ["file:///path1/A/file.pdf", "aws:///path2/B/file.pdf"],
       #     template: "file:///dest1/{{dir_parts[-1..-1]}}/{{ filename }}")
       #   => ["file:///dest1/A/file.pdf", "aws:///dest1/B/file.pdf"]
-      def self.call(from_uri:, template:, adapter: nil, separator: "/")
-        new(from_uri: from_uri, template: template, adapter: adapter, separator: separator).call
+      def self.call(from_uri:, template:, adapter: nil, separator: "/", **options)
+        new(from_uri: from_uri, template: template, adapter: adapter, separator: separator, **options).call
       end
 
-      def initialize(from_uri:, template:, adapter: nil, separator: "/")
+      def initialize(from_uri:, template:, adapter: nil, separator: "/", **options)
         @from_uri = from_uri
         @template = template
         @adapter = adapter
@@ -60,9 +60,10 @@ module DerivativeRodeo
         @from_scheme, @path = uri.split("://")
         @parts = @path.split(separator)
         @dir_parts = @parts[0..-2]
-        @filename = @parts[-1]
-        @basename = File.basename(@filename, ".*")
-        @extension = File.extname(@filename)
+        @filename = options[:filename] || @parts[-1]
+        @basename = options[:basename] || File.basename(@filename, ".*")
+        @extension = options[:extension] || File.extname(@filename)
+        @extension = ".#{@extension}" unless @extension.start_with?(".")
 
         @template_without_query, @template_query = template.split("?")
       end

--- a/lib/derivative_rodeo/storage_locations/base_location.rb
+++ b/lib/derivative_rodeo/storage_locations/base_location.rb
@@ -101,10 +101,10 @@ module DerivativeRodeo
       # @param service [#call, Module<DerivativeRodeo::Services::ConvertUriViaTemplateService>]
       #
       # @return [StorageLocations::BaseLocation]
-      def self.build(from_uri:, template:, service: DerivativeRodeo::Services::ConvertUriViaTemplateService)
+      def self.build(from_uri:, template:, service: DerivativeRodeo::Services::ConvertUriViaTemplateService, **options)
         # HACK: Ensuring that we have the correct scheme.  Maybe this is a hack?
         from_uri = "#{scheme}://#{from_uri}" unless from_uri.start_with?("#{scheme}://")
-        to_uri = service.call(from_uri: from_uri, template: template, adapter: self)
+        to_uri = service.call(from_uri: from_uri, template: template, adapter: self, **options)
         new(to_uri)
       end
 
@@ -203,9 +203,9 @@ module DerivativeRodeo
       # @return [StorageLocations::BaseLocation]
       #
       # @see DerivativeRodeo::Services::ConvertUriViaTemplateService
-      def derived_file_from(template:)
+      def derived_file_from(template:, **options)
         klass = DerivativeRodeo::StorageLocations::BaseLocation.load_location(template)
-        klass.build(from_uri: file_path, template: template)
+        klass.build(from_uri: file_path, template: template, **options)
       end
 
       ##

--- a/lib/derivative_rodeo/storage_locations/sqs_location.rb
+++ b/lib/derivative_rodeo/storage_locations/sqs_location.rb
@@ -181,6 +181,7 @@ module DerivativeRodeo
       end
 
       def output_json(uri)
+        # TODO: Add ability to handle a pre-process-template given to an SQS, and pass that along to the generator when applicable.
         key = DerivativeRodeo::Services::ConvertUriViaTemplateService.call(from_uri: uri, template: template, adapter: self)
         { key => [template] }.to_json
       end

--- a/spec/derivative_rodeo/services/convert_uri_via_template_service_spec.rb
+++ b/spec/derivative_rodeo/services/convert_uri_via_template_service_spec.rb
@@ -17,10 +17,15 @@ RSpec.describe DerivativeRodeo::Services::ConvertUriViaTemplateService do
       { from_uri: "file:///path1/A/file1.pdf",
         template: "file:///dest1/{{dir_parts[-1..-1]}}/{{basename}}/derived{{extension}}",
         adapter: DerivativeRodeo::StorageLocations::FileLocation,
-        expected: "file:///dest1/A/file1/derived.pdf" }
+        expected: "file:///dest1/A/file1/derived.pdf" },
+      { from_uri: "file:///path1/A/file1.pdf",
+        template: "file:///dest1/{{dir_parts[-1..-1]}}/{{basename}}/derived{{extension}}",
+        extension: "hello",
+        adapter: DerivativeRodeo::StorageLocations::FileLocation,
+        expected: "file:///dest1/A/file1/derived.hello" }
     ].each do |hash|
-      context "with from_uri: #{hash.fetch(:from_uri).inspect}, template: #{hash.fetch(:template).inspect}, adapter: #{hash.fetch(:adapter)}" do
-        let(:kwargs) { hash.slice(:from_uri, :template, :adapter) }
+      context "with #{hash.except(:expected)}" do
+        let(:kwargs) { hash.except(:expected) }
 
         it { is_expected.to eq(hash.fetch(:expected)) }
       end


### PR DESCRIPTION
Prior to this commit, we did not account for a generator having a stake in the output URI; that is the extension specified in the generator.

The behavior we saw was that our lambdas completed successfully for the split PDF, OCR, etc.  However, the returned URIs were not the derivative file (e.g. `filename--page-1.thumbnail.jpeg`) but were instead the input file (e.g. `filename--page-1.tiff`) repeated back as output.

With this change, the output and pre-processed template can use the suggested output extension of the generator.

Note: there are probably bugs for cases of SAME extension.  We'll work around that.