### PR TITLE
🐛 Handling "SAME" output extension for templates

### DIFF
--- a/lib/derivative_rodeo/services/convert_uri_via_template_service.rb
+++ b/lib/derivative_rodeo/services/convert_uri_via_template_service.rb
@@ -63,6 +63,8 @@ module DerivativeRodeo
         @filename = options[:filename] || @parts[-1]
         @basename = options[:basename] || File.basename(@filename, ".*")
         @extension = options[:extension] || File.extname(@filename)
+        # When a generator specifies "same" we want to use the given file's extension
+        @extension = File.extname(@filename) if @extension == DerivativeRodeo::StorageLocations::SAME
         @extension = ".#{@extension}" unless @extension.start_with?(".")
 
         @template_without_query, @template_query = template.split("?")

--- a/spec/derivative_rodeo/services/convert_uri_via_template_service_spec.rb
+++ b/spec/derivative_rodeo/services/convert_uri_via_template_service_spec.rb
@@ -22,7 +22,12 @@ RSpec.describe DerivativeRodeo::Services::ConvertUriViaTemplateService do
         template: "file:///dest1/{{dir_parts[-1..-1]}}/{{basename}}/derived{{extension}}",
         extension: "hello",
         adapter: DerivativeRodeo::StorageLocations::FileLocation,
-        expected: "file:///dest1/A/file1/derived.hello" }
+        expected: "file:///dest1/A/file1/derived.hello" },
+      { from_uri: "file:///path1/A/file1.pdf",
+        template: "file:///dest1/{{dir_parts[-1..-1]}}/{{basename}}/derived{{extension}}",
+        extension: DerivativeRodeo::StorageLocations::SAME,
+        adapter: DerivativeRodeo::StorageLocations::FileLocation,
+        expected: "file:///dest1/A/file1/derived.pdf" }
     ].each do |hash|
       context "with #{hash.except(:expected)}" do
         let(:kwargs) { hash.except(:expected) }


### PR DESCRIPTION
Prior to this commit, we were seeing "filename.same" in SpaceStone deploys; that's not a likely extension but instead reflects our "same" convention, namely the output extension of a derivative is the same as the given input.