### PR TITLE
🐛 Hacking away the .mono suffix for 2nd order derivatives

### DIFF
--- a/lib/derivative_rodeo/generators/monochrome_generator.rb
+++ b/lib/derivative_rodeo/generators/monochrome_generator.rb
@@ -5,7 +5,8 @@ module DerivativeRodeo
     ##
     # Take images an ensures that we have a monochrome derivative of those images.
     class MonochromeGenerator < BaseGenerator
-      # TODO: Can we assume a tiff?
+      # @see DerivativeRodeo::Services::ConvertUriViaTemplateService for the interaction of the
+      #      magic ".mono" suffix
       self.output_extension = 'mono.tiff'
 
       ##

--- a/lib/derivative_rodeo/services/convert_uri_via_template_service.rb
+++ b/lib/derivative_rodeo/services/convert_uri_via_template_service.rb
@@ -50,6 +50,7 @@ module DerivativeRodeo
         new(from_uri: from_uri, template: template, adapter: adapter, separator: separator, **options).call
       end
 
+      # rubocop:disable Metrics/MethodLength
       def initialize(from_uri:, template:, adapter: nil, separator: "/", **options)
         @from_uri = from_uri
         @template = template
@@ -62,6 +63,13 @@ module DerivativeRodeo
         @dir_parts = @parts[0..-2]
         @filename = options[:filename] || @parts[-1]
         @basename = options[:basename] || File.basename(@filename, ".*")
+
+        ##
+        # HACK: Because the HocrGenerator has `.mono.tiff` and we are not interested in carrying
+        # forward the `.mono` suffix as that makes it hard to find the preprocessed word
+        # coordinates, alto, and plain text.  This ensures files derived from the .mono are findable
+        # in IIIF Print.
+        @basename = @basename.sub(/\.mono\z/, '')
         @extension = options[:extension] || File.extname(@filename)
         # When a generator specifies "same" we want to use the given file's extension
         @extension = File.extname(@filename) if @extension == DerivativeRodeo::StorageLocations::SAME
@@ -69,6 +77,7 @@ module DerivativeRodeo
 
         @template_without_query, @template_query = template.split("?")
       end
+      # rubocop:enable Metrics/MethodLength
 
       def call
         to_uri = template_without_query.gsub(DIR_PARTS_REPLACEMENT_REGEXP) do |text|

--- a/lib/derivative_rodeo/storage_locations/base_location.rb
+++ b/lib/derivative_rodeo/storage_locations/base_location.rb
@@ -231,6 +231,7 @@ module DerivativeRodeo
       def with_new_extension(extension)
         return file_path if extension == StorageLocations::SAME
 
+        # NOTE: May need to revisit this
         "#{file_path.split('.')[0]}.#{extension}"
       end
 

--- a/spec/derivative_rodeo/services/convert_uri_via_template_service_spec.rb
+++ b/spec/derivative_rodeo/services/convert_uri_via_template_service_spec.rb
@@ -27,7 +27,12 @@ RSpec.describe DerivativeRodeo::Services::ConvertUriViaTemplateService do
         template: "file:///dest1/{{dir_parts[-1..-1]}}/{{basename}}/derived{{extension}}",
         extension: DerivativeRodeo::StorageLocations::SAME,
         adapter: DerivativeRodeo::StorageLocations::FileLocation,
-        expected: "file:///dest1/A/file1/derived.pdf" }
+        expected: "file:///dest1/A/file1/derived.pdf" },
+      { from_uri: "file:///path1/A/file1.mono.tiff",
+        template: "file:///dest1/{{dir_parts[-1..-1]}}/{{basename}}/file1{{extension}}",
+        extension: 'hocr',
+        adapter: DerivativeRodeo::StorageLocations::FileLocation,
+        expected: "file:///dest1/A/file1/file1.hocr" }
     ].each do |hash|
       context "with #{hash.except(:expected)}" do
         let(:kwargs) { hash.except(:expected) }


### PR DESCRIPTION
Given the "20121816.ARCHIVAL--page-3.tiff" page, prior to this commit we were generating the following files:

- 20121816.ARCHIVAL--page-3.mono.alto.xml
- 20121816.ARCHIVAL--page-3.mono.coordinates.json
- 20121816.ARCHIVAL--page-3.mono.hocr
- 20121816.ARCHIVAL--page-3.mono.plain_text.txt
- 20121816.ARCHIVAL--page-3.mono.tiff
- 20121816.ARCHIVAL--page-3.thumbnail.jpeg

Iiif Print finds the derived files for "20121816.ARCHIVAL--page-3.tiff" by looking for the basename (e.g. "20121816.ARCHIVAL--page-3") and then the generator's output extension (e.g. 'plain_text.txt', 'coordinates.json', etc.)

With this change we chop out the ".mono" out of the locations and should see the following:

- 20121816.ARCHIVAL--page-3.alto.xml
- 20121816.ARCHIVAL--page-3.coordinates.json
- 20121816.ARCHIVAL--page-3.hocr
- 20121816.ARCHIVAL--page-3.plain_text.txt
- 20121816.ARCHIVAL--page-3.mono.tiff
- 20121816.ARCHIVAL--page-3.thumbnail.jpeg