### PR TITLE
🐛 Fixing incorrect method name

### DIFF
--- a/lib/derivative_rodeo/errors.rb
+++ b/lib/derivative_rodeo/errors.rb
@@ -35,7 +35,7 @@ module DerivativeRodeo
     ##
     # Raised when AWS bucket does not exist or is not accessible by current permissions
     class BucketMissingError < Error
-      def initialize
+      def initialize(file_uri:)
         super("Bucket part missing #{file_uri}")
       end
     end

--- a/lib/derivative_rodeo/generators/pdf_split_generator.rb
+++ b/lib/derivative_rodeo/generators/pdf_split_generator.rb
@@ -76,7 +76,7 @@ module DerivativeRodeo
 
         return [] if preprocessed_location_template.blank?
 
-        input_location.derived_file_from(template: preprocessed_location_template).globbed_tail_loations(tail_regexp: tail_regexp)
+        input_location.derived_file_from(template: preprocessed_location_template).matching_locations_in_file_dir(tail_regexp: tail_regexp)
       end
 
       ##

--- a/lib/derivative_rodeo/generators/word_coordinates_generator.rb
+++ b/lib/derivative_rodeo/generators/word_coordinates_generator.rb
@@ -33,6 +33,11 @@ module DerivativeRodeo
         File.open(path_to_coordinate, "w+") do |file|
           file.puts service.call(hocr_html).to_json
         end
+      rescue => e
+        message = "🤠🐮 #{self.class}##{__method__} encountered `#{e.class}' error “#{e}” for path_to_hocr: #{path_to_hocr.inspect} and path_to_coordinate: #{path_to_coordinate.inspect}"
+        exception = RuntimeError.new(message)
+        exception.set_backtrace(e.backtrace)
+        raise exception
       end
     end
   end

--- a/lib/derivative_rodeo/storage_locations/s3_location.rb
+++ b/lib/derivative_rodeo/storage_locations/s3_location.rb
@@ -120,7 +120,7 @@ module DerivativeRodeo
       def bucket_name
         @bucket_name ||= file_uri.match(%r{s3://(.+)\.s3})&.[](1)
       rescue StandardError
-        raise Errors::BucketMissingError
+        raise Errors::BucketMissingError.new(file_uri: file_uri)
       end
 
       # @see .use_actual_s3_bucket


### PR DESCRIPTION
This commit includes 3 changes:

1. Replacing a misspelled name with the correct name
2. Improving logging
3. Adding a parameter to an exception.

At one point we had a method `globbed_tail_locations` however with some refactoring I renamed that to `matching_locations_in_file_dir`; however I missed the `globbed_tail_loations`.

In addition to fixing the misnamed method name, I'm adding some improved logging that helps with a problem I've encountered.  Namely that I got a

`#<ArgumentError: invalid byte sequence in UTF-8>` on a string.  That string was the contents of the file found at the `path_to_hocr`; however the exception didn't provide insight into the filename.

With this change, I fix a method that was broken and improve logging.

Last, the exception for buckets used an unprovided variable (e.g. `file_uri`).  This now provides that expected file_uri.

Related to:

- https://github.com/scientist-softserv/derivative_rodeo/issues/56