### PR TITLE
🐛 Correcting preprocessed_location_template for PDF

### DIFF
--- a/lib/derivative_rodeo/generators/base_generator.rb
+++ b/lib/derivative_rodeo/generators/base_generator.rb
@@ -202,7 +202,9 @@ module DerivativeRodeo
           return output_location
         end
 
-        preprocessed_location = input_location.derived_file_from(template: preprocessed_location_template, extension: output_extension)
+        template = derive_preprocessed_template_from(input_location: input_location, preprocessed_location_template: preprocessed_location_template)
+
+        preprocessed_location = input_location.derived_file_from(template: template, extension: output_extension)
         # We only want the location if it exists
         if preprocessed_location&.exist?
           log_message = "#{self.class}#destination :: " \
@@ -226,6 +228,22 @@ module DerivativeRodeo
       end
       # rubocop:enable Metrics/AbcSize
       # rubocop:enable Metrics/MethodLength
+
+      ##
+      # Some generators (e.g. {PdfSplitGenerator}) need to cooerce the location template based on
+      # the input location.  Most often, however, the given :preprocessed_location_template is
+      # adequate and would be the typical returned value.
+      #
+      # @param input_location [StorageLocations::BaseLocation]
+      # @param preprocessed_location_template [String]
+      #
+      # @return [String]
+      #
+      # rubocop:disable Lint/UnusedMethodArgument
+      def derive_preprocessed_template_from(input_location:, preprocessed_location_template:)
+        preprocessed_location_template
+      end
+      # rubocop:enable Lint/UnusedMethodArgument
 
       ##
       # A bit of indirection to create a common interface for running a shell command.

--- a/lib/derivative_rodeo/generators/pdf_split_generator.rb
+++ b/lib/derivative_rodeo/generators/pdf_split_generator.rb
@@ -130,6 +130,16 @@ module DerivativeRodeo
       end
       # rubocop:enable Metrics/AbcSize
       # rubocop:enable Metrics/MethodLength
+
+      ##
+      # We're working with an input location with a filename basename of "123.ARCHIVAL--page-1.tiff"
+      # The :preprocessed_location_template, due to constraints, likely ends with the original PDF's
+      # filename (e.g. "123.ARCHIVAL.pdf")
+      #
+      # And since the template doesn't have a concept of page number, we introduce this kludge.
+      def derive_preprocessed_template_from(input_location:, preprocessed_location_template:)
+        File.join(File.dirname(preprocessed_location_template), input_location.file_name)
+      end
     end
   end
 end


### PR DESCRIPTION
Prior to this commit the `preprocessed_location_template` was the original PDF's location (as in "s3://bucket/aark_id/filename.ARCHIVAL.pdf"). This is because the calling of the generator has one file (e.g. the PDF) and multipe output files (e.g. the pages of the PDF).

What we ideally want is for the `preprocessed_location_template` to handle pages.  To know what page we're on requires knowledge of the `input_location`, and the convention that each "page" ends with the suffix `--page-NUMBER.EXTENSION`.

With this commit, we provide a crease for coercing the template into a page specific format.  If we don't have this change, then we end up using the `filename.ARCHIVAL.pdf` as the "tiff" for each of the pages. This results in very odd behavior, very much unexpected.

Related to:

- https://github.com/scientist-softserv/derivative_rodeo/issues/56