### PR TITLE
🐛 Copying pre-processed files to output location

### DIFF
--- a/spec/derivative_rodeo/generators/base_generator_spec.rb
+++ b/spec/derivative_rodeo/generators/base_generator_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe DerivativeRodeo::Generators::BaseGenerator do
     end
 
     context 'when the output does not exist and the preprocessed location exists' do
-      it 'returns the file at the preprocessed location' do
+      it 'copies the file from the preprocessed location to the output location' do
         Fixtures.with_temporary_directory do |output_location_dir|
           Fixtures.with_temporary_directory do |preprocessed_location_dir|
             output_location = File.join(output_location_dir, File.basename(__FILE__))
@@ -71,12 +71,12 @@ RSpec.describe DerivativeRodeo::Generators::BaseGenerator do
             )
 
             input_file = DerivativeRodeo::StorageLocations::BaseLocation.from_uri(input_uri)
-            destination = instance.destination(input_file)
+            expect do
+              destination = instance.destination(input_file)
 
-            expect(destination.file_path).to eq(preprocessed_location)
-            expect(destination.exist?).to be_truthy
-
-            expect(File.exist?(output_location)).to be_falsey
+              expect(destination.file_path).to eq(output_location)
+              expect(destination.exist?).to be_truthy
+            end.to change { File.exist?(output_location) }.from(false).to(true)
           end
         end
       end


### PR DESCRIPTION
The following user-story reflects the desired behavior:

```gherkin
Given an input uri
When I call #generated_files
Then there will exist a corresponding file at the template-derived output location
```

Prior to this commit, if a file did not exist at the output location but did exist at the pre-processed location, we would return the pre-processed location (which existed).

However, the goal of the `#generated_files` method was to ensure that there were files at the output location based on the input URIs and the output and pre-processed templates.

With this commit, we have a scenario

```gherkin
Given an input uri
And a corresponding template-derived output location that does not exist
And a corresponding template-derived preprocessed location that does exist
When I call #generated_files
Then the we will copy the preprocessed location to the output location
And thus fulfill the contract of #generated_files
```

Related to:

- https://github.com/scientist-softserv/derivative_rodeo/issues/56