### PR TITLE
⚙️ Adding low-level logging

### DIFF
--- a/lib/derivative_rodeo/generators/pdf_split_generator.rb
+++ b/lib/derivative_rodeo/generators/pdf_split_generator.rb
@@ -66,7 +66,7 @@ module DerivativeRodeo
       #
       # @note There is relation to {Generators::BaseGenerator#destination} and this method.
       #
-      # @note The tail_glob is in relation to the {#image_file_basename_template}
+      # @note The tail_regexp is in relation to the {#image_file_basename_template}
       def existing_page_locations(input_location:)
         # See image_file_basename_template
         tail_regexp = %r{#{input_location.file_basename}--page-\d+\.#{output_extension}$}

--- a/lib/derivative_rodeo/storage_locations/base_location.rb
+++ b/lib/derivative_rodeo/storage_locations/base_location.rb
@@ -46,6 +46,8 @@ module DerivativeRodeo
         delegate :config, to: DerivativeRodeo
       end
 
+      delegate :logger, to: DerivativeRodeo
+
       ##
       # @param location_name [String]
       #

--- a/lib/derivative_rodeo/storage_locations/file_location.rb
+++ b/lib/derivative_rodeo/storage_locations/file_location.rb
@@ -42,6 +42,9 @@ module DerivativeRodeo
       #
       # @param tail_regexp [Regexp]
       def matching_locations_in_file_dir(tail_regexp:)
+        logger.debug("#{self.class}##{__method__} searching for matching files in " \
+                    "file_dir: #{file_dir.inspect} " \
+                    "with tail_regexp: #{tail_regexp.inspect}.")
         Dir.glob(File.join(file_dir, "*")).each_with_object([]) do |filename, accumulator|
           accumulator << derived_file_from(template: "file://#{filename}") if tail_regexp.match(filename)
         end

--- a/lib/derivative_rodeo/storage_locations/s3_location.rb
+++ b/lib/derivative_rodeo/storage_locations/s3_location.rb
@@ -73,7 +73,10 @@ module DerivativeRodeo
       def matching_locations_in_file_dir(tail_regexp:)
         uri = URI.parse(file_uri)
         scheme_and_host = "#{uri.scheme}://#{uri.host}"
-
+        logger.debug("#{self.class}##{__method__} searching for matching files for " \
+                    "scheme_and_host: #{scheme_and_host.inspect} " \
+                    "file_dir: #{file_dir.inspect} " \
+                    "with tail_regexp: #{tail_regexp.inspect}.")
         bucket.objects(prefix: file_dir).each_with_object([]) do |object, accumulator|
           if tail_regexp.match(object.key)
             template = File.join(scheme_and_host, object.key)


### PR DESCRIPTION
As I'm working through how files are moving through the DerivativeRodeo, I am needing lower level information to get insight into what's happening.

This commit, introduces debug level logging regarding finding files that were generated as part of the pre-processing of splitting the PDF.

Related to:

- https://github.com/scientist-softserv/derivative_rodeo/issues/56