### PR TITLE
🧹 Add nuanced logging for FileMissingError

### DIFF
--- a/lib/derivative_rodeo/errors.rb
+++ b/lib/derivative_rodeo/errors.rb
@@ -43,6 +43,9 @@ module DerivativeRodeo
     ##
     # Raised when trying to write a tmp file that does not exist
     class FileMissingError < Error
+      def self.with_info(**info)
+        new(info.inspect)
+      end
     end
 
     ##

--- a/lib/derivative_rodeo/storage_locations/concerns/download_concern.rb
+++ b/lib/derivative_rodeo/storage_locations/concerns/download_concern.rb
@@ -23,8 +23,8 @@ module DerivativeRodeo
       delegate :config, to: DerivativeRodeo
 
       def with_existing_tmp_path(&block)
-        with_tmp_path(lambda { |_file_path, tmp_file_path, exist|
-          raise Errors::FileMissingError unless exist
+        with_tmp_path(lambda { |file_path, tmp_file_path, exist|
+          raise Errors::FileMissingError.with_info(method: __method__, context: self, file_path: file_path, tmp_file_path: tmp_file_path) unless exist
 
           response = get(file_uri)
           File.open(tmp_file_path, 'wb') { |fp| fp.write(response.body) }

--- a/lib/derivative_rodeo/storage_locations/file_location.rb
+++ b/lib/derivative_rodeo/storage_locations/file_location.rb
@@ -16,7 +16,7 @@ module DerivativeRodeo
 
       def with_existing_tmp_path(&block)
         with_tmp_path(lambda { |file_path, tmp_file_path, exist|
-          raise Errors::FileMissingError unless exist
+          raise Errors::FileMissingError.with_info(method: __method__, context: self, file_path: file_path, tmp_file_path: tmp_file_path) unless exist
 
           FileUtils.cp(file_path, tmp_file_path)
         }, &block)

--- a/lib/derivative_rodeo/storage_locations/s3_location.rb
+++ b/lib/derivative_rodeo/storage_locations/s3_location.rb
@@ -47,7 +47,7 @@ module DerivativeRodeo
       # @return [String] the path to the tmp file
       def with_existing_tmp_path(&block)
         with_tmp_path(lambda { |file_path, tmp_file_path, exist|
-                        raise Errors::FileMissingError unless exist
+                        raise Errors::FileMissingError.with_info(method: __method__, context: self, file_path: file_path, tmp_file_path: tmp_file_path) unless exist
                         obj = bucket.object(file_path)
                         obj.download_file(tmp_file_path)
                       }, &block)


### PR DESCRIPTION
Prior to this commit many of the FileMissingError had no context of what
file was missing.

With this commit we can see more specific details of what's missing and
hopefully provide better insight into the specific file failure.