### PR TITLE
🐛 Add missing `#matching_locations_in_file_dir` method

### DIFF
--- a/lib/derivative_rodeo/storage_locations/concerns/download_concern.rb
+++ b/lib/derivative_rodeo/storage_locations/concerns/download_concern.rb
@@ -20,7 +20,7 @@ module DerivativeRodeo
         end
       end
 
-      delegate :config, to: DerivativeRodeo
+      delegate :logger, to: DerivativeRodeo
 
       def with_existing_tmp_path(&block)
         with_tmp_path(lambda { |file_path, tmp_file_path, exist|
@@ -44,9 +44,9 @@ module DerivativeRodeo
       #
       # @return [String]
       def get(url)
-        HTTParty.get(url, logger: config.logger)
+        HTTParty.get(url, logger: logger)
       rescue => e
-        config.logger.error(%(#{e.message}\n#{e.backtrace.join("\n")}))
+        logger.error(%(#{e.message}\n#{e.backtrace.join("\n")}))
         raise e
       end
 
@@ -55,10 +55,23 @@ module DerivativeRodeo
       # @return [FalseClass] when the URL's head request is not successful or we've exhausted our
       #         remaining redirects.
       def exist?
-        HTTParty.head(file_uri, logger: config.logger)
+        HTTParty.head(file_uri, logger: logger)
       rescue => e
-        config.logger.error(%(#{e.message}\n#{e.backtrace.join("\n")}))
+        logger.error(%(#{e.message}\n#{e.backtrace.join("\n")}))
         false
+      end
+
+      ##
+      # @param tail_regexp [Regex] the file pattern that we're looking to find; but due to the
+      #        nature of this location adapter, it won't matter.
+      # @return [Array] always returns an empty array.
+      #
+      # @see S3Location#matching_locations_in_file_dir
+      # @see FileLocation#matching_locations_in_file_dir
+      def matching_locations_in_file_dir(tail_regexp:)
+        logger.info("#{self.class}##{__method__} for file_uri: #{file_uri.inspect}, tail_regexp: #{tail_regexp} will always return an empty array.  This is the nature of the #{self.class} location.")
+
+        []
       end
     end
   end

--- a/spec/derivative_rodeo/storage_locations/http_location_spec.rb
+++ b/spec/derivative_rodeo/storage_locations/http_location_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe DerivativeRodeo::StorageLocations::HttpLocation do
+  let(:input_uri) { "http://hello.com/path/to/source.txt" }
+  subject(:instance) { described_class.new(input_uri) }
+
+  context '#matching_locations_in_file_dir' do
+    subject { instance.matching_locations_in_file_dir(tail_regexp: %r{.*}) }
+
+    it { is_expected.to be_empty }
+
+    it 'logs info explaining the reason for always being empty' do
+      expect(instance.logger).to receive(:info).with(String)
+
+      subject
+    end
+  end
+end

--- a/spec/derivative_rodeo/storage_locations/https_location_spec.rb
+++ b/spec/derivative_rodeo/storage_locations/https_location_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe DerivativeRodeo::StorageLocations::HttpsLocation do
+  let(:input_uri) { "https://hello.com/path/to/source.txt" }
+  subject(:instance) { described_class.new(input_uri) }
+
+  context '#matching_locations_in_file_dir' do
+    subject { instance.matching_locations_in_file_dir(tail_regexp: %r{.*}) }
+
+    it { is_expected.to be_empty }
+
+    it 'logs info explaining the reason for always being empty' do
+      expect(instance.logger).to receive(:info).with(String)
+
+      subject
+    end
+  end
+end


### PR DESCRIPTION
In working towards gracefully handling a failed copy of a resource in
SpaceStone, we conditionally updated the `preprocess_template_location` to
be the original HTTP(s) location.  The idea being that if it does not
exist in the pre-processed location

The
[DerivativeRodeo::Generators::PdfSplitGenerator](https://github.com/scientist-softserv/derivative_rodeo/blob/84aa08e8387f105488a2b1a1e3821abacff4ad64/lib/derivative_rodeo/generators/pdf_split_generator.rb#L70-L80)
method (see below) can gracefully handle returning an empty list of
output locations.

```ruby
def existing_page_locations(input_location:)
  # See image_file_basename_template
  tail_regexp = %r{#{input_location.file_basename}--page-\d+\.#{output_extension}$}

  output_locations = input_location.derived_file_from(template: output_location_template).matching_locations_in_file_dir(tail_regexp: tail_regexp)
  return output_locations if output_locations.count.positive?

  return [] if preprocessed_location_template.blank?

  input_location.derived_file_from(template: preprocessed_location_template).matching_locations_in_file_dir(tail_regexp: tail_regexp)
end
```

At issue is understanding if we need to use the copy task to copy the
file locally.  We shall see once this is in play.

Related to:

- https://github.com/scientist-softserv/iiif_print/pull/283
- https://github.com/scientist-softserv/derivative_rodeo/issues/71