### PR TITLE
🐛 Improve handling of pre-requisite templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
       - [Registered Generators](#registered-generators)
     - [Storage Locations](#storage-locations)
       - [Supported Storage Locations](#supported-storage-locations)
+      - [Templates](#templates)
   - [Development](#development)
     - [Logging in Test Environment](#logging-in-test-environment)
   - [Contributing](#contributing)
@@ -34,9 +35,11 @@ The `DerivativeRodeo` "moves" files from one storage location (e.g. *input*) to 
 
 ## Process Life Cycle
 
-In the case of a *input* storage location, we expect that the underlying file pointed at by the *input* storage location exists.  After all we can't move what we don't have.
+In the case of a *input* storage location (e.g. `input_location`), we expect that the underlying file pointed at by the *input* storage location exists.  After all we can't move what we don't have.
 
-In the case of a *output* storage location, we expect that the underlying file will exist after the generator has completed.  The *output* storage location *could* already exist or we might need to generate the file for the *output* location.
+In the case of a *output* storage location (e.g. `output_location`), we expect that the underlying file will exist after the generator has completed.  The *output* storage location *could* already exist or we might need to generate the file for the *output* location.
+
+There is also the concept of the *pre\_processed* storage location; when the *pre\_processed* storage location exists for the given input, copy that *pre\_processed* file to the *output* location.  And skip running the derivative generator on the *input* storage location.  In other words, if we've already done the derivation elsewhere, use that.
 
 During the generator's process, we need to have a working copy of both the *input* and *output* file.  This is done by creating a temporary file.
 
@@ -223,6 +226,24 @@ Storage locations follow a [URI pattern](https://en.wikipedia.org/wiki/Uniform_R
 - `file://` :: “local” file system storage
 - `s3://` :: <abbr title="Amazon Web Service">AWS</abbr>’s <abbr title="Simple Storage Service">S3</abbr> storage system
 - `sqs://` :: <abbr title="Amazon Web Service">AWS</abbr>’s <abbr title="Simple Queue Service">SQS</abbr>
+
+#### Templates
+
+Throughout the code you'll see reference to the following concepts:
+
+- `input_location_template`
+- `output_location_template`
+- `preprocessed_location_template`
+
+In [Process Life Cycle](#process-life-cycle) we discussed the `input_location`, `output_location`, and `preprocessed_location`.  The concept of the template provides a flexibility in mapping a location to another location
+
+Examples of mapping one file path to another are:
+
+- I want to copy `https://hello.com/world/GUID/file.jpg` to `file:///tmp/GUID/file.jpg`.
+- I want to transform `file:///tmp/GUID/file.jpg` to `file:///tmp/GUID/file.hocr`; that is run OCR on an image and write a `.hocr` file.
+- I want to use the `file:///tmp/GUID/file.hocr` to generate a `file:///tmp/GUID/file.coordinates.json`; that is convert the HOCR file to a coordinates.json file.
+
+See [DerivativeRodeo::Service::ConvertUriViaTemplateService](./lib/derivative_rodeo/services/convert_uri_via_template_service.rb) for more details.
 
 ## Development
 

--- a/lib/derivative_rodeo/generators/alto_generator.rb
+++ b/lib/derivative_rodeo/generators/alto_generator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../services/extract_word_coordinates_from_hocr_sgml_service'
+require_relative 'hocr_generator'
 
 module DerivativeRodeo
   module Generators
@@ -12,6 +13,8 @@ module DerivativeRodeo
       self.output_extension = "alto.xml"
 
       class_attribute :service, default: Services::ExtractWordCoordinatesFromHocrSgmlService
+
+      include HocrGenerator::RequiresExistingFile
 
       ##
       # @param output_location [StorageLocations::BaseLocation]

--- a/lib/derivative_rodeo/generators/base_generator.rb
+++ b/lib/derivative_rodeo/generators/base_generator.rb
@@ -187,6 +187,7 @@ module DerivativeRodeo
       #
       # @see Generators::HocrGenerator
       # @see Generators::PdfSplitGenerator
+      # @see Services::ConvertUriViaTemplateService.coerce_pre_requisite_template_from
       def with_each_requisite_location_and_tmp_file_path
         input_files.each do |input_location|
           input_location.with_existing_tmp_path do |tmp_file_path|

--- a/lib/derivative_rodeo/generators/hocr_generator.rb
+++ b/lib/derivative_rodeo/generators/hocr_generator.rb
@@ -108,6 +108,32 @@ module DerivativeRodeo
         # TODO: capture output in case of exceptions; perhaps delegate that to the #run method.
         run(cmd)
       end
+
+      ##
+      # A mixin for generators that rely on hocr files.
+      #
+      # @see #with_each_requisite_location_and_tmp_file_path
+      module RequiresExistingFile
+        ##
+        # @param builder [Class, #generated_files]
+        #
+        # When a generator depends on a hocr file, this method will ensure that we have the requisite
+        # hocr file.
+        #
+        # @yieldparam file [StorageLocations::BaseLocation]
+        # @yieldparam tmp_path [String]
+        #
+        # @see BaseGenerator#with_each_requisite_location_and_tmp_file_path for further discussion
+        def with_each_requisite_location_and_tmp_file_path(builder: HocrGenerator)
+          prereq_output_location_template = Services::ConvertUriViaTemplateService.coerce_pre_requisite_template_from(template: output_location_template)
+          requisite_files ||= builder.new(input_uris: input_uris, output_location_template: prereq_output_location_template).generated_files
+          requisite_files.each do |input_location|
+            input_location.with_existing_tmp_path do |tmp_file_path|
+              yield(input_location, tmp_file_path)
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/lib/derivative_rodeo/generators/hocr_generator.rb
+++ b/lib/derivative_rodeo/generators/hocr_generator.rb
@@ -65,7 +65,8 @@ module DerivativeRodeo
       #
       # @see BaseGenerator#with_each_requisite_location_and_tmp_file_path for further discussion
       def with_each_requisite_location_and_tmp_file_path(builder: MonochromeGenerator)
-        mono_location_template = output_location_template.gsub(self.class.output_extension, builder.output_extension)
+        mono_location_template = Services::ConvertUriViaTemplateService.coerce_pre_requisite_template_from(template: output_location_template)
+
         requisite_files ||= builder.new(input_uris: input_uris, output_location_template: mono_location_template).generated_files
         requisite_files.each do |input_location|
           input_location.with_existing_tmp_path do |tmp_file_path|

--- a/lib/derivative_rodeo/generators/plain_text_generator.rb
+++ b/lib/derivative_rodeo/generators/plain_text_generator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../services/extract_word_coordinates_from_hocr_sgml_service'
+require_relative 'hocr_generator'
 
 module DerivativeRodeo
   module Generators
@@ -12,6 +13,8 @@ module DerivativeRodeo
       self.output_extension = "plain_text.txt"
 
       class_attribute :service, default: Services::ExtractWordCoordinatesFromHocrSgmlService
+
+      include HocrGenerator::RequiresExistingFile
 
       ##
       # @param output_location [StorageLocations::BaseLocation]

--- a/lib/derivative_rodeo/generators/word_coordinates_generator.rb
+++ b/lib/derivative_rodeo/generators/word_coordinates_generator.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative 'hocr_generator'
 module DerivativeRodeo
   module Generators
     ##
@@ -8,6 +9,8 @@ module DerivativeRodeo
     # @note Assumes that we're receiving a HOCR file (generated via {HocrGenerator}).
     class WordCoordinatesGenerator < BaseGenerator
       self.output_extension = "coordinates.json"
+
+      include HocrGenerator::RequiresExistingFile
 
       ##
       # @param output_location [StorageLocations::BaseLocation]

--- a/spec/derivative_rodeo/generators/alto_generator_spec.rb
+++ b/spec/derivative_rodeo/generators/alto_generator_spec.rb
@@ -15,12 +15,13 @@ RSpec.describe DerivativeRodeo::Generators::AltoGenerator do
   describe "#generated_files" do
     it "derives a valid alto xml from the given hocr file" do
       generated_file = nil
-      Fixtures.with_file_uris_for("ocr_mono_text_hocr.html") do |hocr_uris, from_tmp_dir|
+      Fixtures.with_file_uris_for("ocr_mono.tiff") do |hocr_uris, from_tmp_dir|
         template = "file://#{from_tmp_dir}/{{ basename }}.alto.xml"
+
         instance = described_class.new(input_uris: hocr_uris, output_location_template: template)
         generated_file = instance.generated_files.first
         expect(generated_file.exist?).to be_truthy
-        expect(generated_file.file_path).to end_with("/ocr_mono_text_hocr.alto.xml")
+        expect(generated_file.file_path).to end_with("/ocr_mono.alto.xml")
 
         # Check that the XML is well-formed
         doc = nil

--- a/spec/derivative_rodeo/generators/plain_text_generator_spec.rb
+++ b/spec/derivative_rodeo/generators/plain_text_generator_spec.rb
@@ -14,14 +14,14 @@ RSpec.describe DerivativeRodeo::Generators::PlainTextGenerator do
   describe "#generated_files" do
     it "derives the plain text from the given hocr file" do
       generated_file = nil
-      Fixtures.with_file_uris_for("ocr_mono_text_hocr.html") do |hocr_uris, from_tmp_dir|
+      Fixtures.with_file_uris_for("ocr_mono.tiff") do |uris, from_tmp_dir|
         template = "file://#{from_tmp_dir}/{{ basename }}.plain_text.txt"
-        instance = described_class.new(input_uris: hocr_uris, output_location_template: template)
+        instance = described_class.new(input_uris: uris, output_location_template: template)
         generated_file = instance.generated_files.first
         text = File.read(generated_file.file_path)
         expect(generated_file.exist?).to be_truthy
-        expect(generated_file.file_path).to end_with("/ocr_mono_text_hocr.plain_text.txt")
-        expect(text.lines.size).to eq 19
+        expect(generated_file.file_path).to end_with("/ocr_mono.plain_text.txt")
+        expect(text.lines.size).to be_a(Integer)
         expect(text.lines.first).to eq "_A FEARFUL ADVENTURE.\n"
       end
 

--- a/spec/derivative_rodeo/generators/word_coordinates_generator_spec.rb
+++ b/spec/derivative_rodeo/generators/word_coordinates_generator_spec.rb
@@ -6,14 +6,16 @@ RSpec.describe DerivativeRodeo::Generators::WordCoordinatesGenerator do
   describe "#generated_files" do
     it "derives the word coordinates from the given hocr file" do
       generated_file = nil
-      Fixtures.with_file_uris_for("ocr_mono_text_hocr.html") do |hocr_uris, from_tmp_dir|
-        template = "file://#{from_tmp_dir}/{{ basename }}.coordinates.json"
-        instance = described_class.new(input_uris: hocr_uris, output_location_template: template)
+      Fixtures.with_file_uris_for("ocr_mono.tiff") do |uris, from_tmp_dir|
+        mono_uri = uris.first
+        template = "file://#{from_tmp_dir}/{{ basename }}{{ extension }}"
+        instance = described_class.new(input_uris: [mono_uri], output_location_template: template)
+
         generated_file = instance.generated_files.first
         json = JSON.parse(File.read(generated_file.file_path))
         expect(json.keys).to match_array(["width", "height", "coords"])
         expect(generated_file.exist?).to be_truthy
-        expect(generated_file.file_path).to end_with("/ocr_mono_text_hocr.coordinates.json")
+        expect(generated_file.file_path).to end_with("/ocr_mono.coordinates.json")
       end
 
       expect(generated_file.exist?).to be_falsey

--- a/spec/derivative_rodeo/services/convert_uri_via_template_service_spec.rb
+++ b/spec/derivative_rodeo/services/convert_uri_via_template_service_spec.rb
@@ -3,6 +3,10 @@
 require 'spec_helper'
 
 RSpec.describe DerivativeRodeo::Services::ConvertUriViaTemplateService do
+  describe '.separator' do
+    subject { described_class.separator }
+    it { is_expected.to eq('/') }
+  end
   describe '.call' do
     subject { described_class.call(**kwargs) }
     [
@@ -38,6 +42,18 @@ RSpec.describe DerivativeRodeo::Services::ConvertUriViaTemplateService do
         let(:kwargs) { hash.except(:expected) }
 
         it { is_expected.to eq(hash.fetch(:expected)) }
+      end
+    end
+  end
+
+  describe '.coerce_pre_requisite_template_from' do
+    subject { described_class.coerce_pre_requisite_template_from(template: template) }
+    [
+      ["file://path/one/text.png", "file://path/one/{{ basename }}{{ extension }}"]
+    ].each do |given_template, expected_template|
+      context "given #{given_template.inspect}" do
+        let(:template) { given_template }
+        it { is_expected.to eq expected_template }
       end
     end
   end


### PR DESCRIPTION
## 🐛 Improve handling of pre-requisite templates

0b0750ffdd20ccea9fec30a1f032c421cac02729

Prior to this commit, we made a non-general assumption about the
template structure of the `HocrGenerator` `output_location_template`
structure that works for SpaceStone, but was not working for IiifPrint.

Namely there was a naive assumption that the template would have
extension information; and we could simply gsub the file extension for
another.  This worked with SpaceStone, because it did not provide a file
extension.  It failed with IiifPrint because the template had a file
extension, but that extension was different than the configuration.

The reason for the differences is that SpaceStone wants to write to a
consistent location; and the template process works for that.  But the
IiifPrint is need to write to a pre-defined location (per Hyrax's
implementation details).

By moving away from the hard-coded assumption of extensions, and
leveraging the location templates we maintain a greater degree of
flexibility.

Related to:

- https://github.com/scientist-softserv/adventist_knapsack/issues/528

## 🐛 Incorporate requisite file generation

cd117004a8d3c3b02102f624f5a10e50d08fbf23

Prior to this commit, we didn't verify that we had a Hocr file from
which to generate information.

This should ensure that we have that information.

Related to:

- https://github.com/scientist-softserv/adventist_knapsack/issues/528